### PR TITLE
Rename "generate" command to "new"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ DESCRIPTION:
    mixtool helps with generating, building and linting jsonnet mixins
 
 COMMANDS:
-     build     Build manifests from jsonnet input
-     generate  Generate jsonnet mixin files
-     lint      Lint jsonnet files
-     help, h   Shows a list of commands or help for one command
+     build    Build manifests from jsonnet input
+     lint     Lint jsonnet files
+     new      Create new jsonnet mixin files
+     help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --help, -h     show help
@@ -73,32 +73,32 @@ $ mixtool build --yaml=false prometheus.jsonnet > prometheus.json
 $ mixtool build --multi prometheus/ prometheus.jsonnet
 ```
 
-### Generate
+### New
 
-[embedmd]:# (_output/help-generate.txt)
+[embedmd]:# (_output/help-new.txt)
 ```txt
 NAME:
-   mixtool generate - Generate files for Prometheus alerts & rules and Grafana dashboards as jsonnet mixin
+   mixtool new - Create new files for Prometheus alerts & rules and Grafana dashboards as jsonnet mixin
 
 USAGE:
-   mixtool generate command [command options] [arguments...]
+   mixtool new command [command options] [arguments...]
 
 COMMANDS:
-     grafana-dashboard  Generate a new file for a Grafana dashboard
-     prometheus-alerts  Generate a new file for Prometheus alerts
-     prometheus-rules   Generate a new file for Prometheus rules
+     grafana-dashboard  Create a new file with a Grafana dashboard mixin inside
+     prometheus-alerts  Create a new file with Prometheus alert mixins inside
+     prometheus-rules   Create a new file with Prometheus rule mixins inside
 
 OPTIONS:
    --help, -h  show help
    
 ```
 
-#### Generate Examples
+#### New Examples
 
 ```bash
-$ mixtool generate grafana-dashboard > my-dashboard.jsonnet
-$ mixtool generate prometheus-alerts > my-alerts.jsonnet
-$ mixtool generate prometheus-rules > my-rules.jsonnet
+$ mixtool new grafana-dashboard > my-dashboard.jsonnet
+$ mixtool new prometheus-alerts > my-alerts.jsonnet
+$ mixtool new prometheus-rules > my-rules.jsonnet
 ```
 
 ### Lint

--- a/cmd/mixtool/main.go
+++ b/cmd/mixtool/main.go
@@ -34,8 +34,8 @@ func main() {
 
 	app.Commands = cli.Commands{
 		buildCommand(),
-		generateCommand(),
 		lintCommand(),
+		newCommand(),
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/cmd/mixtool/new.go
+++ b/cmd/mixtool/new.go
@@ -22,53 +22,53 @@ import (
 	"github.com/urfave/cli"
 )
 
-func generateCommand() cli.Command {
+func newCommand() cli.Command {
 	return cli.Command{
-		Name:        "generate",
-		Usage:       "Generate jsonnet mixin files",
-		Description: "Generate files for Prometheus alerts & rules and Grafana dashboards as jsonnet mixin",
+		Name:        "new",
+		Usage:       "Create new jsonnet mixin files",
+		Description: "Create new files for Prometheus alerts & rules and Grafana dashboards as jsonnet mixin",
 		Subcommands: cli.Commands{
 			cli.Command{
 				Name:   "grafana-dashboard",
-				Usage:  "Generate a new file for a Grafana dashboard",
-				Action: generateGrafanaDashboard,
+				Usage:  "Create a new file with a Grafana dashboard mixin inside",
+				Action: newGrafanaDashboard,
 			},
 			cli.Command{
 				Name:   "prometheus-alerts",
-				Usage:  "Generate a new file for Prometheus alerts",
-				Action: generatePrometheusAlerts,
+				Usage:  "Create a new file with Prometheus alert mixins inside",
+				Action: newPrometheusAlerts,
 			},
 			cli.Command{
 				Name:   "prometheus-rules",
-				Usage:  "Generate a new file for Prometheus rules",
-				Action: generatePrometheusRules,
+				Usage:  "Create a new file with Prometheus rule mixins inside",
+				Action: newPrometheusRules,
 			},
 		},
 	}
 }
 
-func generateGrafanaDashboard(c *cli.Context) error {
+func newGrafanaDashboard(c *cli.Context) error {
 	if fileExists(c.Args().First()) {
 		return fmt.Errorf("file already exists. not overwriting.")
 	}
 
-	return writeFileToDisk(c, mixer.GenerateGrafanaDashboard)
+	return writeFileToDisk(c, mixer.NewGrafanaDashboard)
 }
 
-func generatePrometheusAlerts(c *cli.Context) error {
+func newPrometheusAlerts(c *cli.Context) error {
 	if fileExists(c.Args().First()) {
 		return fmt.Errorf("file already exists. not overwriting.")
 	}
 
-	return writeFileToDisk(c, mixer.GeneratePrometheusAlerts)
+	return writeFileToDisk(c, mixer.NewPrometheusAlerts)
 }
 
-func generatePrometheusRules(c *cli.Context) error {
+func newPrometheusRules(c *cli.Context) error {
 	if fileExists(c.Args().First()) {
 		return fmt.Errorf("file already exists. not overwriting.")
 	}
 
-	return writeFileToDisk(c, mixer.GeneratePrometheusRules)
+	return writeFileToDisk(c, mixer.NewPrometheusRules)
 }
 
 func fileExists(filename string) bool {
@@ -94,7 +94,7 @@ func writeFileToDisk(c *cli.Context, creator func() ([]byte, error)) error {
 
 	out, err := creator()
 	if err != nil {
-		return fmt.Errorf("failed to generate rules: %v", err)
+		return fmt.Errorf("failed to create new rules: %v", err)
 	}
 
 	f.Write(out)

--- a/pkg/mixer/new.go
+++ b/pkg/mixer/new.go
@@ -61,7 +61,7 @@ local graphPanel = grafana.graphPanel;
 }
 `
 
-func GenerateGrafanaDashboard() ([]byte, error) {
+func NewGrafanaDashboard() ([]byte, error) {
 	return []byte(dashboard), nil
 }
 
@@ -91,7 +91,7 @@ const alerts = `{
 }
 `
 
-func GeneratePrometheusAlerts() ([]byte, error) {
+func NewPrometheusAlerts() ([]byte, error) {
 	return []byte(alerts), nil
 }
 
@@ -116,6 +116,6 @@ const rules = `{
 }
 `
 
-func GeneratePrometheusRules() ([]byte, error) {
+func NewPrometheusRules() ([]byte, error) {
 	return []byte(rules), nil
 }

--- a/pkg/mixer/new_test.go
+++ b/pkg/mixer/new_test.go
@@ -18,30 +18,30 @@ import (
 	"testing"
 )
 
-func TestGenerateGrafanaDashboard(t *testing.T) {
-	d, err := GenerateGrafanaDashboard()
+func TestNewGrafanaDashboard(t *testing.T) {
+	d, err := NewGrafanaDashboard()
 	if err != nil {
-		t.Errorf("failed to generate Grafana dashboard: %v", err)
+		t.Errorf("failed to create new Grafana dashboard: %v", err)
 	}
 	if string(d) != dashboard {
 		t.Error("returned dashboard is not correct")
 	}
 }
 
-func TestGeneratePrometheusAlerts(t *testing.T) {
-	a, err := GeneratePrometheusAlerts()
+func TestNewPrometheusAlerts(t *testing.T) {
+	a, err := NewPrometheusAlerts()
 	if err != nil {
-		t.Errorf("failed to generate Prometheus alerts: %v", err)
+		t.Errorf("failed to create new Prometheus alerts: %v", err)
 	}
 	if string(a) != alerts {
 		t.Error("returned Prometheus alerts is not correct")
 	}
 }
 
-func TestGeneratePrometheusRules(t *testing.T) {
-	r, err := GeneratePrometheusRules()
+func TestNewPrometheusRules(t *testing.T) {
+	r, err := NewPrometheusRules()
 	if err != nil {
-		t.Errorf("failed to generate Prometheus rules: %v", err)
+		t.Errorf("failed to create new Prometheus rules: %v", err)
 	}
 	if string(r) != rules {
 		t.Error("returned Prometheus rules is not correct")

--- a/scripts/generate-help-txt.sh
+++ b/scripts/generate-help-txt.sh
@@ -5,5 +5,5 @@ GOOS=$(uname -s | tr A-Z a-z)
 
 $PWD/_output/$GOOS/amd64/$BINARY_NAME -h > $PWD/_output/help.txt
 $PWD/_output/$GOOS/amd64/$BINARY_NAME build -h > $PWD/_output/help-build.txt
-$PWD/_output/$GOOS/amd64/$BINARY_NAME generate -h > $PWD/_output/help-generate.txt
 $PWD/_output/$GOOS/amd64/$BINARY_NAME lint -h > $PWD/_output/help-lint.txt
+$PWD/_output/$GOOS/amd64/$BINARY_NAME new -h > $PWD/_output/help-new.txt


### PR DESCRIPTION
In the last week I more and more felt like _generate_ is not the correct wording for the command that simply outputs some files. Hence renaming to _new_ seems like the best option.

Additionally, I'm still unsure if the _build_ command is the correct wording either.
Maybe we should simply make it the default command (as it is in jsonnet itself) when a input file is given.

/cc @brancz @ant31